### PR TITLE
Fetch Missions

### DIFF
--- a/src/components/pages/mission.js
+++ b/src/components/pages/mission.js
@@ -1,7 +1,21 @@
-function mission() {
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { loadMissions } from '../../redux/missions/missions';
+
+const mission = () => {
+  const missionsList = useSelector((state) => state.missions);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!missionsList.length) {
+      dispatch(loadMissions());
+    }
+  }, []);
+
   return (
-    <div>mission</div>
+    <div>Check console for state updates.</div>
   );
-}
+};
 
 export default mission;

--- a/src/components/pages/mission.js
+++ b/src/components/pages/mission.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { loadMissions } from '../../redux/missions/missions';
 
 const mission = () => {
-  const missionsList = useSelector((state) => state.missions);
+  const missionsList = useSelector(({ missionsReducer }) => missionsReducer);
 
   const dispatch = useDispatch();
 

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,5 +1,5 @@
 const api = 'https://api.spacexdata.com/v3/missions';
-const GET_MISSIONS = 'missions/GET_MISSIONS';
+const GET_MISSIONS = 'redux/missions/GET_MISSIONS';
 
 const fetchData = () => {
   const data = fetch(api)

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -8,3 +8,20 @@ const fetchData = () => {
 };
 
 const getMissions = async () => fetchData();
+
+const handleData = (data) => {
+  const missions = [];
+
+  data.forEach((mission) => {
+    const { mission_id: id, mission_name: name, description } = mission;
+    const newMission = {
+      id,
+      name,
+      description,
+      joined: false,
+    };
+    missions.push(newMission);
+  });
+
+  return missions;
+};

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,4 +1,5 @@
 const api = 'https://api.spacexdata.com/v3/missions';
+const GET_MISSIONS = 'missions/GET_MISSIONS';
 
 const fetchData = () => {
   const data = fetch(api)
@@ -25,3 +26,23 @@ const handleData = (data) => {
 
   return missions;
 };
+
+const loadMissions = () => async (dispatch) => {
+  const missions = await getMissions();
+
+  dispatch({
+    type: GET_MISSIONS,
+    playload: handleData(missions),
+  });
+};
+
+const missionsReducer = (state = [], action) => {
+  switch (action.type) {
+    case GET_MISSIONS:
+      return action.playload;
+    default:
+      return state;
+  }
+};
+
+export { missionsReducer, loadMissions };

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -45,4 +45,5 @@ const missionsReducer = (state = [], action) => {
   }
 };
 
-export { missionsReducer, loadMissions };
+export default missionsReducer;
+export { loadMissions };

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,3 +1,10 @@
-const missionsReducer = () => null;
+const api = 'https://api.spacexdata.com/v3/missions';
 
-export default missionsReducer;
+const fetchData = () => {
+  const data = fetch(api)
+    .then((response) => response.json())
+    .then((data) => data);
+  return data;
+};
+
+const getMissions = async () => fetchData();


### PR DESCRIPTION
In this branch, I created the first action for the missionsReducer.

When the missions page is loaded, the app fetches the API and updates the missions state slice.

Since we are not rendering the missions yet, please check the console logger in order to confirm the state has been successfully updated.

This update only happens the first time the missions page is visited, just as required by the project requierements.